### PR TITLE
Show player count on main page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -87,6 +87,11 @@
                             <p>Identifica quién ha sido el pedorro y quiénes los peditos</p>
                             <p>¡Basándote solo en los sonidos!</p>
                         </div>
+                        
+                        <!-- Distribución de roles -->
+                        <div id="roles-distribution" class="roles-distribution">
+                            <!-- Se generará dinámicamente -->
+                        </div>
                     </div>
                     
 

--- a/web/lib.js
+++ b/web/lib.js
@@ -224,6 +224,51 @@ export const calculateGameRoles = (totalPlayers) => {
     };
 };
 
+// Función pura para obtener la distribución de roles para mostrar al usuario
+export const getRolesDistribution = (totalPlayers) => {
+    // Validar que totalPlayers sea un número
+    if (typeof totalPlayers !== 'number' || !Number.isInteger(totalPlayers)) {
+        return {
+            success: false,
+            error: 'Número de jugadores debe ser un número entero'
+        };
+    }
+    
+    // Validar rango de jugadores (4-16 según PRODUCT_BRIEF)
+    if (totalPlayers < 4 || totalPlayers > 16) {
+        return {
+            success: false,
+            error: 'Número de jugadores debe estar entre 4 y 16'
+        };
+    }
+    
+    // Tabla de distribución según PRODUCT_BRIEF
+    const roleDistribution = {
+        4: { peditos: 2, pedorros: 1, neutrales: 1 },
+        5: { peditos: 2, pedorros: 1, neutrales: 2 },
+        6: { peditos: 3, pedorros: 1, neutrales: 2 },
+        7: { peditos: 4, pedorros: 1, neutrales: 2 },
+        8: { peditos: 4, pedorros: 1, neutrales: 3 },
+        9: { peditos: 5, pedorros: 1, neutrales: 3 },
+        10: { peditos: 6, pedorros: 1, neutrales: 3 },
+        11: { peditos: 6, pedorros: 1, neutrales: 4 },
+        12: { peditos: 7, pedorros: 1, neutrales: 4 },
+        13: { peditos: 8, pedorros: 1, neutrales: 4 },
+        14: { peditos: 8, pedorros: 1, neutrales: 5 },
+        15: { peditos: 9, pedorros: 1, neutrales: 5 },
+        16: { peditos: 10, pedorros: 1, neutrales: 5 }
+    };
+    
+    const distribution = roleDistribution[totalPlayers];
+    
+    return {
+        success: true,
+        peditos: distribution.peditos,
+        pedorros: distribution.pedorros,
+        neutrales: distribution.neutrales
+    };
+};
+
 // Función pura para generar el diccionario de sonidos para cada jugador
 export const generateNextSounds = (roles, totalPlayers) => {
     if (!roles || !roles.success || !roles.peditos || !roles.pedorro) {

--- a/web/script.js
+++ b/web/script.js
@@ -24,6 +24,7 @@ import {
     validateAccusationFormat,
     getAccusationsProgress,
     calculateRoundScore,
+    getRolesDistribution,
     AUTH_STATES
 } from './lib.js';
 
@@ -66,6 +67,31 @@ let accusationsListenerCleanup = null;
 let accusationsData = {};
 
 // ===== FUNCIONES UTILITARIAS PARA MANEJO DE CLASES CSS =====
+
+/**
+ * Renderiza la distribución de roles en la pantalla START
+ * @param {number} totalPlayers - Número total de jugadores
+ */
+const renderRolesDistribution = (totalPlayers) => {
+    const rolesDistributionElement = document.getElementById('roles-distribution');
+    if (!rolesDistributionElement) {
+        return;
+    }
+    
+    // Obtener la distribución de roles
+    const distribution = getRolesDistribution(totalPlayers);
+    
+    if (!distribution.success) {
+        rolesDistributionElement.innerHTML = '';
+        return;
+    }
+    
+    // Crear el texto de distribución
+    const pedorroText = distribution.pedorros === 1 ? '1 pedorro' : `${distribution.pedorros} pedorros`;
+    const peditoText = distribution.peditos === 1 ? '1 pedito' : `${distribution.peditos} peditos`;
+    
+    rolesDistributionElement.innerHTML = `<p>${pedorroText}, ${peditoText}</p>`;
+};
 
 /**
  * Activa un elemento removiendo 'inactive' y añadiendo 'active'
@@ -196,6 +222,11 @@ const renderStartScreen = (gameState) => {
     if (playerInfoElement && playerNumber > 0 && totalPlayers > 0) {
         playerInfoElement.textContent = `Jugador: ${playerNumber} / ${totalPlayers}`;
         playerInfoElement.style.display = 'block';
+    }
+    
+    // Renderizar distribución de roles
+    if (totalPlayers > 0) {
+        renderRolesDistribution(totalPlayers);
     }
     
     // Controlar visibilidad del botón REINICIAR solo para jugador 1

--- a/web/styles.css
+++ b/web/styles.css
@@ -240,6 +240,20 @@ body {
     margin: 10px 0;
 }
 
+/* Distribución de roles */
+.roles-distribution {
+    text-align: center;
+    color: #FFF;
+    opacity: 0.7;
+    font-size: 0.8rem;
+    margin-top: 15px;
+    line-height: 1.4;
+}
+
+.roles-distribution p {
+    margin: 5px 0;
+}
+
 /* Responsive design */
 @media (max-width: 600px) {
     .game-title {


### PR DESCRIPTION
Display the number of 'pedorros' and 'peditos' on the start screen based on player count, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce3cd6cf-6a4f-4cb9-a8ed-3fcab3ab39d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce3cd6cf-6a4f-4cb9-a8ed-3fcab3ab39d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

